### PR TITLE
Resolve 'Invalid key length' error on Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.6
+  - 4
+  - 5
+  - 6

--- a/lib/multipass.js
+++ b/lib/multipass.js
@@ -8,7 +8,7 @@ var api = module.exports = function(apiKey, siteKey) {
   if (!(this instanceof api)) return new api(apiKey, siteKey);
   if (!(typeof apiKey == 'string' && apiKey.length > 0)) throw new Error('Invalid API key');
   if (!(typeof siteKey == 'string' && siteKey.length > 0)) throw new Error('Invalid site key');
-  this._key = crypto.createHash('sha1').update(apiKey + siteKey).digest('binary').substring(0, BLOCK_SIZE);
+  this._key = crypto.createHash('sha1').update(apiKey + siteKey).digest().slice(0, BLOCK_SIZE);
   this._iv = new Buffer('OpenSSL for Ruby', 'ascii');
   return this;
 };


### PR DESCRIPTION
This change adds support for Node 6 LTS and tests against all modern versions of Node. See https://github.com/nodejs/node/issues/6696.
